### PR TITLE
ci: only publish on "published" event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 on:
   release:
     types:
-      - released
+      - published
 
 jobs:
   PushLooseTag:


### PR DESCRIPTION
From our testing, this is the only event that triggers once-and-only-once per release.